### PR TITLE
Fix numerical scheme for heat equation

### DIFF
--- a/content/2.04_HeatEquation.rst
+++ b/content/2.04_HeatEquation.rst
@@ -40,7 +40,7 @@ With the grid defined, one can use the following explicit approximation for the 
 
 .. math::
 
-    \frac{U^{n+1}_{i,j}-U^{n}_{i,j}}{dt}=a\left(\frac{U^n_{i-1,j}-2U^{n}_{i,j}+U^n_{i+1,j}}{dx} + \frac{U^n_{i,j-1}-2U^{n}_{i,j}+U^n_{i,j+1}}{dx}\right)
+    \frac{U^{n+1}_{i,j}-U^{n}_{i,j}}{dt}=a\left(\frac{U^n_{i-1,j}-2U^{n}_{i,j}+U^n_{i+1,j}}{{dx}^{2}} + \frac{U^n_{i,j-1}-2U^{n}_{i,j}+U^n_{i,j+1}}{{dy}^{2}}\right)
 
 Here we used basic approximations for the first and second derivatives :math:`\frac{df}{dx}\approx\frac{f(x+dx)-f(x)}{dx}` and :math:`\frac{d^2f}{dx^2}\approx\frac{f(x-dx)-2f(x)+f(x+dx)}{dx^2}`.
 In the equation above, the values on the next time step, :math:`U^{n+1}_{i,j}` are unknown.
@@ -54,7 +54,7 @@ The numerical scheme can then be rearranged to give an explicit expression for t
 
 .. math::
 
-    U^{n+1}_{i,j}= U^{n}_{i,j} + dh\cdot a\left(\frac{U^n_{i-1,j}-2U^{n}_{i,j}+U^n_{i+1,j}}{dx} + \frac{U^n_{i,j-1}-2U^{n}_{i,j}+U^n_{i,j+1}}{dx}\right)
+    U^{n+1}_{i,j}= U^{n}_{i,j} + dh\cdot a\left(\frac{U^n_{i-1,j}-2U^{n}_{i,j}+U^n_{i+1,j}}{{dx}^{2}} + \frac{U^n_{i,j-1}-2U^{n}_{i,j}+U^n_{i,j+1}}{{dy}^{2}}\right)
 
 And this is the expression we are going to use in our code.
 


### PR DESCRIPTION
1. Squares on spacial step sizes were missing in second-order  derivatives
2. Steps were dx in both x and y directions